### PR TITLE
ci: update build scripts to use production build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: build
         run: |
           yarn
-          yarn run build
+          yarn run build:prod
 
       # Package the required files into a zip
       - name: Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
         run: yarn run lint
 
       - name: Run Build
-        run: yarn run build
+        run: yarn run build:prod


### PR DESCRIPTION
Switch from using `yarn run build` to `yarn run build:prod`
in both release and test workflows to ensure production
builds are consistently used, improving performance
and reliability in deployment and testing processes.